### PR TITLE
Add to build commands to solve various R related problems

### DIFF
--- a/.ebextensions/01_install_r.config
+++ b/.ebextensions/01_install_r.config
@@ -8,8 +8,10 @@ commands:
       sudo mkswap /swapfile
       sudo swapon /swapfile
   01_install_R:
-    command: sudo yum install -y R
+    command: |
+      sudo yum install -y R openssl-dev libcurl-devel fribidi-devel freetype-devel libpng-devel libtiff-devel libjpeg-devel
   02_install_R_packages:
     command: |
-      sudo R -e 'install.packages(c("devtools","ggplot2","dplyr"), repos="https://cran.r-project.org")'
+      sudo R -e 'install.packages(c("devtools","ggplot2","dplyr","BiocManager"), repos="https://cran.r-project.org")'
+      sudo R -e 'BiocManager::install(c("GenomicRanges","S4Vectors","GenomeInfoDb"), ask=FALSE)'
       sudo R -e 'devtools::install_github("dzhang32/ggtranscript")'

--- a/.ebextensions/01_install_r.config
+++ b/.ebextensions/01_install_r.config
@@ -1,5 +1,12 @@
 ---
 commands:
+  # Required so long as EC2 instance is of type t3.micro
+  00_create_swap:
+    command: |
+      sudo fallocate -l 2G /swapfile
+      sudo chmod 600 /swapfile
+      sudo mkswap /swapfile
+      sudo swapon /swapfile
   01_install_R:
     command: sudo yum install -y R
   02_install_R_packages:


### PR DESCRIPTION
Firstly, EC2 instance is t3.micro, so there is very little ram available to the system. This was solved via swap files.

Secondly, R libraries didn't install properly due to missing system files and BiocManager not being used to grab certain package dependencies for ggtranscript.